### PR TITLE
Fix dsp file with removing non-existed files

### DIFF
--- a/licecap/licecap_cli.dsp
+++ b/licecap/licecap_cli.dsp
@@ -132,10 +132,6 @@ SOURCE=..\WDL\libpng\pngerror.c
 # End Source File
 # Begin Source File
 
-SOURCE=..\WDL\libpng\pnggccrd.c
-# End Source File
-# Begin Source File
-
 SOURCE=..\WDL\libpng\pngget.c
 # End Source File
 # Begin Source File
@@ -169,10 +165,6 @@ SOURCE=..\WDL\libpng\pngset.c
 # Begin Source File
 
 SOURCE=..\WDL\libpng\pngtrans.c
-# End Source File
-# Begin Source File
-
-SOURCE=..\WDL\libpng\pngvcrd.c
 # End Source File
 # Begin Source File
 


### PR DESCRIPTION
`pnggccrd.c` and `pngvcrd.c` do not exist any more, so `licecap_cli.dsp` should be modified. Test successfully under VS2017 and VS2019.